### PR TITLE
Resolve Issue #2 : Flush output on error or throw

### DIFF
--- a/include/Logger.h
+++ b/include/Logger.h
@@ -47,7 +47,7 @@
 #define LogTraceOnce            (LogTraceImpl( true, true ))
 
 // To make assertions
-#define LogThrowIf2(isThrowing_, errorMessage_)  if(isThrowing_){(LogError << "(" << __PRETTY_FUNCTION__ << "): "<< errorMessage_ << std::endl).throwError(#isThrowing_);}
+#define LogThrowIf2(isThrowing_, errorMessage_)  if(isThrowing_){(LogError << "(" << __PRETTY_FUNCTION__ << "): "<< errorMessage_ << std::endl).throwError(#isThrowing_ ": " #errorMessage_);}
 #define LogThrowIf1(isThrowing_) LogThrowIf2(isThrowing_, #isThrowing_)
 #define LogThrowIf(...) GET_OVERLOADED_MACRO2(__VA_ARGS__, LogThrowIf2, LogThrowIf1)(__VA_ARGS__)
 #define LogAssert(assertion_, errorMessage_)    LogThrowIf(not (assertion_), errorMessage_)

--- a/include/implementation/Logger.impl.h
+++ b/include/implementation/Logger.impl.h
@@ -32,7 +32,8 @@
   static void* MAKE_VARNAME_LINE(LoggerInitPlaceHolder) = []{ \
     try{ lambdaInit(); }         \
     catch( ... ){                  \
-      std::cout << "Error occurred during LoggerInit within the lamda instruction. Please check." << std::endl; \
+      if (Logger::getStreamBufferSupervisorPtr() != nullptr) Logger::getStreamBufferSupervisorPtr()->flush(); \
+      std::cerr << "Error occurred during LoggerInit within the lamda instruction. Please check." << std::endl; \
       throw std::runtime_error("Error occurred during LoggerInit"); \
     } \
     return nullptr; \
@@ -249,6 +250,7 @@ namespace {
     std::stringstream ss;
     ss << "exception thrown by the logger";
     ss << (errorStr_.empty()? "." : ":" + errorStr_);
+    if (Logger::getStreamBufferSupervisorPtr() != nullptr) Logger::getStreamBufferSupervisorPtr()->flush();
     throw std::runtime_error( ss.str() );
   }
 

--- a/include/implementation/LoggerUtils.h
+++ b/include/implementation/LoggerUtils.h
@@ -94,6 +94,11 @@ namespace LoggerUtils{
       if( _outFileStream_.is_open() ) _outFileStream_ << f;
       return *this;
     }
+    StreamBufferSupervisor &flush(){
+         if(*_outputStream_) _outputStream_->flush();
+         if(_outFileStream_.is_open()) _outFileStream_.flush();
+         return *this;
+    }
 
   private:
     std::streambuf* _streamBufferPtr_{nullptr};


### PR DESCRIPTION
This adds flush before throwing an error.  All of the log output goes to the same streams, so there is no distinction for LogError and friends.